### PR TITLE
Remove Elasticsearch cluster configuration option

### DIFF
--- a/conf/reference.conf
+++ b/conf/reference.conf
@@ -34,8 +34,6 @@ play.http.session.cookieName = CORTEX_SESSION
 search {
   # Name of the index
   index = cortex
-  # Name of the ElasticSearch cluster
-  cluster = hive
   # Address of the ElasticSearch instance
   host = ["127.0.0.1:9300"]
   # Scroll keepalive

--- a/docker/cortex/docker-compose.yml
+++ b/docker/cortex/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     image: elasticsearch:6.8.0
     environment:
       - http.host=0.0.0.0
-      - cluster.name=hive
       - thread_pool.index.queue_size=100000
       - thread_pool.search.queue_size=100000
       - thread_pool.bulk.queue_size=100000


### PR DESCRIPTION
The support for Elastichsearch cluster was dropped in
elastic4play: https://github.com/TheHive-Project/elastic4play/commit/61b536dba876dc1e4a2b55d496f5e8bc01c31db7#diff-f07ac33940a7ee923aad7704a1ce276aL75
