### PR TITLE
Point to latest stable version of Cortex image in `docker-compose` file

### DIFF
--- a/docker/cortex/docker-compose.yml
+++ b/docker/cortex/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - thread_pool.search.queue_size=100000
       - thread_pool.bulk.queue_size=100000
   cortex:
-    image: thehiveproject/cortex:3.0.0-RC4
+    image: thehiveproject/cortex:3.0.1
     depends_on:
       - elasticsearch
     ports:


### PR DESCRIPTION
Make `docker-compose` file point to latest Cortex stable image, instead of pointing to an RC image.