### PR TITLE
Update application.sample

### DIFF
--- a/conf/application.sample
+++ b/conf/application.sample
@@ -14,7 +14,7 @@ search {
   index = cortex
   # ElasticSearch instance address.
   # For cluster, join address:port with ',': "http://ip1:9200,ip2:9200,ip3:9200"
-  uri = "http://127.0.0.1:9200"
+  #uri = "http://127.0.0.1:9200"
 
   ## Advanced configuration
   # Scroll keepalive.


### PR DESCRIPTION
Uncomment elasticsearch URL so that we can set this via docker entrypoint and users with baremetal installation can only activate it.