### PR TITLE
Fixed user parameter name in application config sample

### DIFF
--- a/conf/application.sample
+++ b/conf/application.sample
@@ -32,7 +32,7 @@ search {
   #}
 
   ## Authentication configuration
-  #username = ""
+  #user = ""
   #password = ""
 
   ## SSL configuration


### PR DESCRIPTION
Sample contained username as field name for authentication against Elasticsearch. This has to be user though or no auth is performed.