### PR TITLE
Add -m option to 'su' so the environment variables will be preserved

### DIFF
--- a/package/docker/entrypoint
+++ b/package/docker/entrypoint
@@ -169,7 +169,7 @@ then
 
   chown -R cortex:cortex "$CONFIG_FILE" /etc/cortex
   test -e /var/run/docker.sock && chown cortex:cortex /var/run/docker.sock
-  su - cortex -c "/opt/cortex/bin/cortex \
+  su -m cortex -c "/opt/cortex/bin/cortex \
     -Dconfig.file=$CONFIG_FILE \
     -Dlogger.file=/etc/cortex/logback.xml \
     -Dpidfile.path=/dev/null \


### PR DESCRIPTION
Without this option, the cortex process will start without being able to access any of the environment variables and will fail to properly start as a result.