### PR TITLE
Refactor JSON format for attribute errors in Elastic4Play

### DIFF
--- a/elastic4play/app/org/elastic4play/JsonFormat.scala
+++ b/elastic4play/app/org/elastic4play/JsonFormat.scala
@@ -4,6 +4,8 @@ import java.util.Date
 
 import scala.util.{Failure, Success, Try}
 
+import scala.reflect.ClassTag
+
 import play.api.libs.json._
 
 import org.elastic4play.controllers.JsonFormat.inputValueFormat
@@ -14,21 +16,21 @@ object JsonFormat {
   private val dateWrites: Writes[Date]  = Writes[Date](d => JsNumber(d.getTime))
   implicit val dateFormat: Format[Date] = Format(dateReads, dateWrites)
 
-  private def attributeErrorWrites[E <: AttributeError](underlying: OWrites[E], tpe: String): OWrites[E] = {
-    val discriminator: (String, JsValue) = "type" -> JsString(tpe)
+  private def attributeErrorWrites[E <: AttributeError](underlying: OWrites[E])(implicit cls: ClassTag[E]): OWrites[E] = {
+    val discriminator: (String, JsValue) = "type" -> JsString(cls.runtimeClass.getSimpleName)
 
     OWrites.transform(underlying) { (origErr, obj) =>
       obj + discriminator + ("message" -> JsString(origErr.toString))
     }
   }
 
-  private[elastic4play] val invalidFormatAttributeErrorWrites: OWrites[InvalidFormatAttributeError] = attributeErrorWrites[InvalidFormatAttributeError](Json.writes[InvalidFormatAttributeError], "InvalidFormatAttributeError")
+  private[elastic4play] val invalidFormatAttributeErrorWrites: OWrites[InvalidFormatAttributeError] = attributeErrorWrites[InvalidFormatAttributeError](Json.writes[InvalidFormatAttributeError])
 
-  private[elastic4play] val unknownAttributeErrorWrites: OWrites[UnknownAttributeError] = attributeErrorWrites[UnknownAttributeError](Json.writes[UnknownAttributeError], "UnknownAttributeError")
+  private[elastic4play] val unknownAttributeErrorWrites: OWrites[UnknownAttributeError] = attributeErrorWrites[UnknownAttributeError](Json.writes[UnknownAttributeError])
 
-  private[elastic4play] val updateReadOnlyAttributeErrorWrites: OWrites[UpdateReadOnlyAttributeError] = attributeErrorWrites[UpdateReadOnlyAttributeError](Json.writes[UpdateReadOnlyAttributeError], "UpdateReadOnlyAttributeError")
+  private[elastic4play] val updateReadOnlyAttributeErrorWrites: OWrites[UpdateReadOnlyAttributeError] = attributeErrorWrites[UpdateReadOnlyAttributeError](Json.writes[UpdateReadOnlyAttributeError])
 
-  private[elastic4play] val missingAttributeErrorWrites: OWrites[MissingAttributeError] = attributeErrorWrites(Json.writes[MissingAttributeError], "MissingAttributeError")
+  private[elastic4play] val missingAttributeErrorWrites: OWrites[MissingAttributeError] = attributeErrorWrites(Json.writes[MissingAttributeError])
 
   implicit val attributeCheckingExceptionWrites: OWrites[AttributeCheckingError] = OWrites[AttributeCheckingError] { ace =>
     Json.obj(

--- a/elastic4play/app/org/elastic4play/JsonFormat.scala
+++ b/elastic4play/app/org/elastic4play/JsonFormat.scala
@@ -14,7 +14,7 @@ object JsonFormat {
   private val dateWrites: Writes[Date]  = Writes[Date](d => JsNumber(d.getTime))
   implicit val dateFormat: Format[Date] = Format(dateReads, dateWrites)
 
-  private def attributeErrorWrites[E <: AttributeError](underlying: OWrites[E])(tpe: String): OWrites[E] = {
+  private def attributeErrorWrites[E <: AttributeError](underlying: OWrites[E], tpe: String): OWrites[E] = {
     val discriminator: (String, JsValue) = "type" -> JsString(tpe)
 
     OWrites.transform(underlying) { (origErr, obj) =>
@@ -22,26 +22,13 @@ object JsonFormat {
     }
   }
 
-  private[elastic4play] val invalidFormatAttributeErrorWrites = OWrites[InvalidFormatAttributeError] { ifae =>
-    Json.writes[InvalidFormatAttributeError].writes(ifae) +
-      ("type"    -> JsString("InvalidFormatAttributeError")) +
-      ("message" -> JsString(ifae.toString))
-  }
-  private[elastic4play] val unknownAttributeErrorWrites = OWrites[UnknownAttributeError] { uae =>
-    Json.writes[UnknownAttributeError].writes(uae) +
-      ("type"    -> JsString("UnknownAttributeError")) +
-      ("message" -> JsString(uae.toString))
-  }
-  private[elastic4play] val updateReadOnlyAttributeErrorWrites = OWrites[UpdateReadOnlyAttributeError] { uroae =>
-    Json.writes[UpdateReadOnlyAttributeError].writes(uroae) +
-      ("type"    -> JsString("UpdateReadOnlyAttributeError")) +
-      ("message" -> JsString(uroae.toString))
-  }
-  private[elastic4play] val missingAttributeErrorWrites = OWrites[MissingAttributeError] { mae =>
-    Json.writes[MissingAttributeError].writes(mae) +
-      ("type"    -> JsString("MissingAttributeError")) +
-      ("message" -> JsString(mae.toString))
-  }
+  private[elastic4play] val invalidFormatAttributeErrorWrites: OWrites[InvalidFormatAttributeError] = attributeErrorWrites[InvalidFormatAttributeError](Json.writes[InvalidFormatAttributeError], "InvalidFormatAttributeError")
+
+  private[elastic4play] val unknownAttributeErrorWrites: OWrites[UnknownAttributeError] = attributeErrorWrites[UnknownAttributeError](Json.writes[UnknownAttributeError], "UnknownAttributeError")
+
+  private[elastic4play] val updateReadOnlyAttributeErrorWrites: OWrites[UpdateReadOnlyAttributeError] = attributeErrorWrites[UpdateReadOnlyAttributeError](Json.writes[UpdateReadOnlyAttributeError], "UpdateReadOnlyAttributeError")
+
+  private[elastic4play] val missingAttributeErrorWrites: OWrites[MissingAttributeError] = attributeErrorWrites(Json.writes[MissingAttributeError], "MissingAttributeError")
 
   implicit val attributeCheckingExceptionWrites: OWrites[AttributeCheckingError] = OWrites[AttributeCheckingError] { ace =>
     Json.obj(

--- a/elastic4play/app/org/elastic4play/JsonFormat.scala
+++ b/elastic4play/app/org/elastic4play/JsonFormat.scala
@@ -16,33 +16,31 @@ object JsonFormat {
   private val dateWrites: Writes[Date]  = Writes[Date](d => JsNumber(d.getTime))
   implicit val dateFormat: Format[Date] = Format(dateReads, dateWrites)
 
-  private def attributeErrorWrites[E <: AttributeError](underlying: OWrites[E])(implicit cls: ClassTag[E]): OWrites[E] = {
-    val discriminator: (String, JsValue) = "type" -> JsString(cls.runtimeClass.getSimpleName)
-
+  private def attributeErrorWrites[E <: AttributeError](underlying: OWrites[E]): OWrites[E] = {
     OWrites.transform(underlying) { (origErr, obj) =>
-      obj + discriminator + ("message" -> JsString(origErr.toString))
+      obj + ("message" -> JsString(origErr.toString))
     }
   }
 
-  private[elastic4play] val invalidFormatAttributeErrorWrites: OWrites[InvalidFormatAttributeError] = attributeErrorWrites[InvalidFormatAttributeError](Json.writes[InvalidFormatAttributeError])
+  private[elastic4play] implicit val invalidFormatAttributeErrorWrites: OWrites[InvalidFormatAttributeError] = attributeErrorWrites[InvalidFormatAttributeError](Json.writes[InvalidFormatAttributeError])
 
-  private[elastic4play] val unknownAttributeErrorWrites: OWrites[UnknownAttributeError] = attributeErrorWrites[UnknownAttributeError](Json.writes[UnknownAttributeError])
+  private[elastic4play] implicit val unknownAttributeErrorWrites: OWrites[UnknownAttributeError] = attributeErrorWrites[UnknownAttributeError](Json.writes[UnknownAttributeError])
 
-  private[elastic4play] val updateReadOnlyAttributeErrorWrites: OWrites[UpdateReadOnlyAttributeError] = attributeErrorWrites[UpdateReadOnlyAttributeError](Json.writes[UpdateReadOnlyAttributeError])
+  private[elastic4play] implicit val updateReadOnlyAttributeErrorWrites: OWrites[UpdateReadOnlyAttributeError] = attributeErrorWrites[UpdateReadOnlyAttributeError](Json.writes[UpdateReadOnlyAttributeError])
 
-  private[elastic4play] val missingAttributeErrorWrites: OWrites[MissingAttributeError] = attributeErrorWrites(Json.writes[MissingAttributeError])
+  private[elastic4play] implicit val missingAttributeErrorWrites: OWrites[MissingAttributeError] = attributeErrorWrites(Json.writes[MissingAttributeError])
 
-  implicit val attributeCheckingExceptionWrites: OWrites[AttributeCheckingError] = OWrites[AttributeCheckingError] { ace =>
-    Json.obj(
-      "tableName" -> ace.tableName,
-      "type"      -> "AttributeCheckingError",
-      "errors" -> JsArray(ace.errors.map {
-        case e: InvalidFormatAttributeError  => invalidFormatAttributeErrorWrites.writes(e)
-        case e: UnknownAttributeError        => unknownAttributeErrorWrites.writes(e)
-        case e: UpdateReadOnlyAttributeError => updateReadOnlyAttributeErrorWrites.writes(e)
-        case e: MissingAttributeError        => missingAttributeErrorWrites.writes(e)
-      })
-    )
+  implicit val attributeCheckingExceptionWrites: OWrites[AttributeCheckingError] = {
+    val pkgName = classOf[AttributeError].getPackage.getName + '.'
+
+    implicit def errWrites: OWrites[AttributeError] = Json.configured(JsonConfiguration(
+      discriminator = "type",
+      typeNaming = JsonNaming(_.stripPrefix(pkgName))
+    )).writes
+
+    val discriminator = "type" -> JsString("AttributeCheckingError")
+
+    Json.writes[AttributeCheckingError].transform(_ + discriminator)
   }
 
   implicit def tryWrites[A](implicit aWrites: Writes[A]): Writes[Try[A]] = Writes[Try[A]] {

--- a/elastic4play/app/org/elastic4play/JsonFormat.scala
+++ b/elastic4play/app/org/elastic4play/JsonFormat.scala
@@ -14,22 +14,30 @@ object JsonFormat {
   private val dateWrites: Writes[Date]  = Writes[Date](d => JsNumber(d.getTime))
   implicit val dateFormat: Format[Date] = Format(dateReads, dateWrites)
 
-  private val invalidFormatAttributeErrorWrites = Writes[InvalidFormatAttributeError] { ifae =>
+  private def attributeErrorWrites[E <: AttributeError](underlying: OWrites[E])(tpe: String): OWrites[E] = {
+    val discriminator: (String, JsValue) = "type" -> JsString(tpe)
+
+    OWrites.transform(underlying) { (origErr, obj) =>
+      obj + discriminator + ("message" -> JsString(origErr.toString))
+    }
+  }
+
+  private[elastic4play] val invalidFormatAttributeErrorWrites = OWrites[InvalidFormatAttributeError] { ifae =>
     Json.writes[InvalidFormatAttributeError].writes(ifae) +
       ("type"    -> JsString("InvalidFormatAttributeError")) +
       ("message" -> JsString(ifae.toString))
   }
-  private val unknownAttributeErrorWrites = Writes[UnknownAttributeError] { uae =>
+  private[elastic4play] val unknownAttributeErrorWrites = OWrites[UnknownAttributeError] { uae =>
     Json.writes[UnknownAttributeError].writes(uae) +
       ("type"    -> JsString("UnknownAttributeError")) +
       ("message" -> JsString(uae.toString))
   }
-  private val updateReadOnlyAttributeErrorWrites = Writes[UpdateReadOnlyAttributeError] { uroae =>
+  private[elastic4play] val updateReadOnlyAttributeErrorWrites = OWrites[UpdateReadOnlyAttributeError] { uroae =>
     Json.writes[UpdateReadOnlyAttributeError].writes(uroae) +
       ("type"    -> JsString("UpdateReadOnlyAttributeError")) +
       ("message" -> JsString(uroae.toString))
   }
-  private val missingAttributeErrorWrites = Writes[MissingAttributeError] { mae =>
+  private[elastic4play] val missingAttributeErrorWrites = OWrites[MissingAttributeError] { mae =>
     Json.writes[MissingAttributeError].writes(mae) +
       ("type"    -> JsString("MissingAttributeError")) +
       ("message" -> JsString(mae.toString))

--- a/elastic4play/test/org/elastic4play/JsonFormatSpec.scala
+++ b/elastic4play/test/org/elastic4play/JsonFormatSpec.scala
@@ -8,52 +8,91 @@ final class JsonFormatSpec extends org.specs2.mutable.Specification {
   "Play JSON format for Elastic".title
 
   "Format for attribute errors" should {
+    val invalidFormatAttrErr = InvalidFormatAttributeError(
+      name = "Test 1",
+      format = "Foo",
+      value = JsonInputValue(JsString("Input")))
+
+    val invalidFormatAttrErrJson = Json.obj(
+      "name" -> "Test 1",
+      "format" -> "Foo",
+      "value" -> Json.obj("type" -> "JsonInputValue", "value" -> "Input"),
+      "type" -> "InvalidFormatAttributeError",
+      "message" -> "Invalid format for Test 1: JsonInputValue(\"Input\"), expected Foo")
+
     "support InvalidFormatAttributeError" in {
       implicit def w: OWrites[InvalidFormatAttributeError] =
         JsonFormat.invalidFormatAttributeErrorWrites
 
-      Json.toJsObject(InvalidFormatAttributeError(
-        name = "Test 1",
-        format = "Foo",
-        value = JsonInputValue(JsString("Input")))) must_=== Json.obj(
-          "name" -> "Test 1",
-          "format" -> "Foo",
-          "value" -> Json.obj("type" -> "JsonInputValue", "value" -> "Input"),
-          "type" -> "InvalidFormatAttributeError",
-          "message" -> "Invalid format for Test 1: JsonInputValue(\"Input\"), expected Foo")
+      Json.toJsObject(invalidFormatAttrErr) must_=== invalidFormatAttrErrJson
     }
+
+    val unknownAttrErr = UnknownAttributeError(
+      name = "Test 2",
+      value = JsString("Bar"))
+
+    val unknownAttrErrJson = Json.obj(
+      "name" -> "Test 2",
+      "value" -> "Bar",
+      "type" -> "UnknownAttributeError",
+      "message" -> "Unknown attribute Test 2: \"Bar\"")
 
     "support UnknownAttributeError" in {
       implicit def w: OWrites[UnknownAttributeError] =
         JsonFormat.unknownAttributeErrorWrites
 
-      Json.toJsObject(UnknownAttributeError(
-        name = "Test 2",
-        value = JsString("Bar"))) must_=== Json.obj(
-          "name" -> "Test 2",
-          "value" -> "Bar",
-          "type" -> "UnknownAttributeError",
-          "message" -> "Unknown attribute Test 2: \"Bar\"")
+      Json.toJsObject(unknownAttrErr) must_=== unknownAttrErrJson
     }
+
+    val updateRoAttrErr = UpdateReadOnlyAttributeError("Lorem")
+
+    val updateRoAttrErrJson = Json.obj(
+      "name" -> "Lorem",
+      "type" -> "UpdateReadOnlyAttributeError",
+      "message" -> "Attribute Lorem is read-only")
 
     "support UpdateReadOnlyAttributeError" in {
       implicit def w: OWrites[UpdateReadOnlyAttributeError] =
         JsonFormat.updateReadOnlyAttributeErrorWrites
 
-      Json.toJsObject(UpdateReadOnlyAttributeError("Lorem")) must_=== Json.obj(
-        "name" -> "Lorem",
-        "type" -> "UpdateReadOnlyAttributeError",
-        "message" -> "Attribute Lorem is read-only")
+      Json.toJsObject(updateRoAttrErr) must_=== updateRoAttrErrJson
     }
+
+    val missingAttrErr = MissingAttributeError("Ipsum")
+
+    val missingAttrErrJson = Json.obj(
+      "name" -> "Ipsum",
+      "type" -> "MissingAttributeError",
+      "message" -> "Attribute Ipsum is missing")
 
     "support MissingAttributeError" in {
       implicit def w: OWrites[MissingAttributeError] =
         JsonFormat.missingAttributeErrorWrites
 
-      Json.toJsObject(MissingAttributeError("Ipsum")) must_=== Json.obj(
-        "name" -> "Ipsum",
-        "type" -> "MissingAttributeError",
-        "message" -> "Attribute Ipsum is missing")
+      Json.toJsObject(missingAttrErr) must_=== missingAttrErrJson
+    }
+
+    "support AttributeCheckingError" in {
+      import JsonFormat.attributeCheckingExceptionWrites
+
+      val errors = Seq(invalidFormatAttrErr, unknownAttrErr, updateRoAttrErr, missingAttrErr)
+
+      val errorsJson = Seq(invalidFormatAttrErrJson, unknownAttrErrJson, updateRoAttrErrJson, missingAttrErrJson)
+
+      Json.toJsObject(AttributeCheckingError(
+        tableName = "Table 1",
+        errors = errors)) must_=== Json.obj(
+          "tableName" -> "Table 1",
+          "type" -> "AttributeCheckingError",
+          "errors" -> errorsJson) and {
+        // Reverse errors to make sure the order is preserved
+        Json.toJsObject(AttributeCheckingError(
+          tableName = "Table 2",
+          errors = errors.reverse)) must_=== Json.obj(
+          "tableName" -> "Table 2",
+            "type" -> "AttributeCheckingError",
+            "errors" -> errorsJson.reverse)
+      }
     }
   }
 }

--- a/elastic4play/test/org/elastic4play/JsonFormatSpec.scala
+++ b/elastic4play/test/org/elastic4play/JsonFormatSpec.scala
@@ -17,7 +17,6 @@ final class JsonFormatSpec extends org.specs2.mutable.Specification {
       "name" -> "Test 1",
       "format" -> "Foo",
       "value" -> Json.obj("type" -> "JsonInputValue", "value" -> "Input"),
-      "type" -> "InvalidFormatAttributeError",
       "message" -> "Invalid format for Test 1: JsonInputValue(\"Input\"), expected Foo")
 
     "support InvalidFormatAttributeError" in {
@@ -34,7 +33,6 @@ final class JsonFormatSpec extends org.specs2.mutable.Specification {
     val unknownAttrErrJson = Json.obj(
       "name" -> "Test 2",
       "value" -> "Bar",
-      "type" -> "UnknownAttributeError",
       "message" -> "Unknown attribute Test 2: \"Bar\"")
 
     "support UnknownAttributeError" in {
@@ -48,7 +46,6 @@ final class JsonFormatSpec extends org.specs2.mutable.Specification {
 
     val updateRoAttrErrJson = Json.obj(
       "name" -> "Lorem",
-      "type" -> "UpdateReadOnlyAttributeError",
       "message" -> "Attribute Lorem is read-only")
 
     "support UpdateReadOnlyAttributeError" in {
@@ -62,7 +59,6 @@ final class JsonFormatSpec extends org.specs2.mutable.Specification {
 
     val missingAttrErrJson = Json.obj(
       "name" -> "Ipsum",
-      "type" -> "MissingAttributeError",
       "message" -> "Attribute Ipsum is missing")
 
     "support MissingAttributeError" in {
@@ -77,7 +73,11 @@ final class JsonFormatSpec extends org.specs2.mutable.Specification {
 
       val errors = Seq(invalidFormatAttrErr, unknownAttrErr, updateRoAttrErr, missingAttrErr)
 
-      val errorsJson = Seq(invalidFormatAttrErrJson, unknownAttrErrJson, updateRoAttrErrJson, missingAttrErrJson)
+      val errorsJson = Seq(
+        (invalidFormatAttrErrJson + ("type" -> JsString("InvalidFormatAttributeError"))),
+        (unknownAttrErrJson + ("type" -> JsString("UnknownAttributeError"))),
+        (updateRoAttrErrJson + ("type" -> JsString("UpdateReadOnlyAttributeError"))),
+        (missingAttrErrJson + ("type" -> JsString("MissingAttributeError"))))
 
       Json.toJsObject(AttributeCheckingError(
         tableName = "Table 1",

--- a/elastic4play/test/org/elastic4play/JsonFormatSpec.scala
+++ b/elastic4play/test/org/elastic4play/JsonFormatSpec.scala
@@ -1,0 +1,59 @@
+package org.elastic4play
+
+import play.api.libs.json._
+
+import org.elastic4play.controllers.JsonInputValue
+
+final class JsonFormatSpec extends org.specs2.mutable.Specification {
+  "Play JSON format for Elastic".title
+
+  "Format for attribute errors" should {
+    "support InvalidFormatAttributeError" in {
+      implicit def w: OWrites[InvalidFormatAttributeError] =
+        JsonFormat.invalidFormatAttributeErrorWrites
+
+      Json.toJsObject(InvalidFormatAttributeError(
+        name = "Test 1",
+        format = "Foo",
+        value = JsonInputValue(JsString("Input")))) must_=== Json.obj(
+          "name" -> "Test 1",
+          "format" -> "Foo",
+          "value" -> Json.obj("type" -> "JsonInputValue", "value" -> "Input"),
+          "type" -> "InvalidFormatAttributeError",
+          "message" -> "Invalid format for Test 1: JsonInputValue(\"Input\"), expected Foo")
+    }
+
+    "support UnknownAttributeError" in {
+      implicit def w: OWrites[UnknownAttributeError] =
+        JsonFormat.unknownAttributeErrorWrites
+
+      Json.toJsObject(UnknownAttributeError(
+        name = "Test 2",
+        value = JsString("Bar"))) must_=== Json.obj(
+          "name" -> "Test 2",
+          "value" -> "Bar",
+          "type" -> "UnknownAttributeError",
+          "message" -> "Unknown attribute Test 2: \"Bar\"")
+    }
+
+    "support UpdateReadOnlyAttributeError" in {
+      implicit def w: OWrites[UpdateReadOnlyAttributeError] =
+        JsonFormat.updateReadOnlyAttributeErrorWrites
+
+      Json.toJsObject(UpdateReadOnlyAttributeError("Lorem")) must_=== Json.obj(
+        "name" -> "Lorem",
+        "type" -> "UpdateReadOnlyAttributeError",
+        "message" -> "Attribute Lorem is read-only")
+    }
+
+    "support MissingAttributeError" in {
+      implicit def w: OWrites[MissingAttributeError] =
+        JsonFormat.missingAttributeErrorWrites
+
+      Json.toJsObject(MissingAttributeError("Ipsum")) must_=== Json.obj(
+        "name" -> "Ipsum",
+        "type" -> "MissingAttributeError",
+        "message" -> "Attribute Ipsum is missing")
+    }
+  }
+}


### PR DESCRIPTION
## Macro derivation of OWrites for individual *AttributeError types

Current `JsonFormat` call macro materialization on each call for the individual attribute error type.

```scala
private val invalidFormatAttributeErrorWrites = Writes[InvalidFormatAttributeError] { ifae =>
    Json.writes[InvalidFormatAttributeError]/* <-- !1! */.writes(ifae) +
      ("type"    -> JsString("InvalidFormatAttributeError")) +
      ("message" -> JsString(ifae.toString))
  }

// !1! Macro materialization of OWrites[InvalidFormatAttributeError] is called each time invalidFormatAttributeErrorWrites.
// Same of `unknownAttributeErrorWrites`, `updateReadOnlyAttributeErrorWrites`, `missingAttributeErrorWrites`.
```

When the current `attributeCheckingExceptionWrites` is used it could also materialize multiple time the same `OWrites[*AttributeError]` for multiple value of the same kind in `errors`.

```scala
implicit val attributeCheckingExceptionWrites: OWrites[AttributeCheckingError] = OWrites[AttributeCheckingError] { ace =>
    Json.obj(
      "tableName" -> ace.tableName,
      "type"      -> "AttributeCheckingError",
      "errors" -> JsArray(ace.errors.map {
        case e: InvalidFormatAttributeError  => invalidFormatAttributeErrorWrites.writes(e)
        case e: UnknownAttributeError        => unknownAttributeErrorWrites.writes(e)
        case e: UpdateReadOnlyAttributeError => updateReadOnlyAttributeErrorWrites.writes(e)
        case e: MissingAttributeError        => missingAttributeErrorWrites.writes(e)
      })
    )
  }
```

This could be improved, as such `OWrites` instances are invariants (do not depend on call).

## 'Manual' OWrites for AttributeCheckingError

The current `OWrites` instance for type `AttributeCheckingError` is 'manually' implemented (see bellow).
It could benefit from using the capability of macro derivation to supported sealed family (there `AttributeError`), so that if a new kind of error is added, it would be supported there without change.

## Approach

A new test suit is introduced, with test(s) covering the existing implementation before any change, to make sure there is no regression.